### PR TITLE
feat: add support for creating a machine-readable json schema

### DIFF
--- a/src/pages/schema.json.ts
+++ b/src/pages/schema.json.ts
@@ -1,0 +1,12 @@
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { jsonSchema } from '../schemas'
+
+export const GET: APIRoute = async () => {
+	return new Response(jsonSchema, {
+		status: 200,
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	})
+}

--- a/src/pages/schema.json.ts
+++ b/src/pages/schema.json.ts
@@ -1,9 +1,8 @@
-import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
 import { jsonSchema } from '../schemas'
 
 export const GET: APIRoute = async () => {
-	return new Response(jsonSchema, {
+	return new Response(JSON.stringify(jsonSchema), {
 		status: 200,
 		headers: {
 			'Content-Type': 'application/json'

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -19,4 +19,5 @@ export const SoftwareSchemaObject = z.object({
 	project: z.optional(omsfProjects)
 })
 
+export const jsonSchema = z.toJSONSchema(SoftwareSchemaObject)
 export type SoftwareSchema = z.infer<typeof SoftwareSchemaObject>


### PR DESCRIPTION
This PR creates a new page holding the schema used for software and workflows as created by Zod. This should help people use this in the future for applications like YAML LSPs or scripts for adding/updating YAML files.
